### PR TITLE
Implemented setPageRatios4

### DIFF
--- a/src/pdfCropMargins/manpage_data.py
+++ b/src/pdfCropMargins/manpage_data.py
@@ -644,12 +644,12 @@ cmd_parser.add_argument("-spr4", "--setPageRatios4", nargs=5, type=str,
                         "FLOAT", "FLOAT"), help="""
 
    This is the same as '--setPageRatios' except that four additonal arguments
-   can be given.  The first argument remains the same, and the four floating
-   point arguments should be the left, bottom, right, and top weights,
-   respectively. The weights determine how much of the necessary height/width
-   increase is added at the respective edge. Negative numbers cause complete
-   margin to the boundary box to be weighted instead of just the margin added
-   to archive the desired page ratio.^^n""")
+   can be given.  The first argument stays, and the four floating point
+   arguments should be the left, bottom, right, and top weights, respectively.
+   The weights determine how much of the necessary height/width increase is
+   added at the respective edge. Negative numbers cause complete margin to the
+   boundary box to be weighted instead of just the margin added to archive the
+   desired page ratio.^^n""")
 
 cmd_parser.add_argument("-dcb", "--docCatBlacklist", default="",
                        metavar="STR", help="""

--- a/src/pdfCropMargins/manpage_data.py
+++ b/src/pdfCropMargins/manpage_data.py
@@ -639,6 +639,18 @@ cmd_parser.add_argument("-spr", "--setPageRatios", nargs=1, type=str,
    string width-to-height ratio such as '4.5:3' or else a floating point number
    like '0.75' which is the width divided by the height.^^n""")
 
+cmd_parser.add_argument("-spr4", "--setPageRatios4", nargs=5, type=str,
+                        default=[], metavar=("FLOAT:FLOAT", "FLOAT", "FLOAT",
+                        "FLOAT", "FLOAT"), help="""
+
+   This is the same as '--setPageRatios' except that four additonal arguments
+   can be given.  The first argument remains the same, and the four floating
+   point arguments should be the left, bottom, right, and top weights,
+   respectively. The weights determine how much of the necessary height/width
+   increase is added at the respective edge. Negative numbers cause complete
+   margin to the boundary box to be weighted instead of just the margin added
+   to archive the desired page ratio.^^n""")
+
 cmd_parser.add_argument("-dcb", "--docCatBlacklist", default="",
                        metavar="STR", help="""
 


### PR DESCRIPTION
I need this to nudge the favor the left/top for aspect-ratio compensating margins, as the ebook has a bookmark UI overlay icon at the top and I'd usually hold it with the left thumb on the left bezel pointing up, and while neither fact prevents reading, both are a nuisance.

I'll probably add additional functionality to force margin sizing measured relative to the final width/height, as the page is scaled to fullscreen anyways and I need the margins so I don't have content where the shadow of the front glass border, my thumb or the bookmark icon impair readability.

If you need test or what not, tell me what I'll need to do and I'll add them (might take a few days).