### PR TITLE
Fix decryption error with non-encrypted file

### DIFF
--- a/src/pdfCropMargins/main_pdfCropMargins.py
+++ b/src/pdfCropMargins/main_pdfCropMargins.py
@@ -1101,7 +1101,7 @@ def process_pdf_file(input_doc_pathname, fixed_input_doc_pathname, output_doc_pa
         try:
             input_doc.decrypt("")
             tmp_input_doc.decrypt("")
-        except KeyError:
+        except (KeyError, PdfReadError):
             pass # Document apparently wasn't encrypted with an empty password.
 
     ##


### PR DESCRIPTION
## Error

When running `pdf-crop-margins` on a non-encrypted file ([Presentation1.pdf](https://github.com/abarker/pdfCropMargins/files/9112744/Presentation1.pdf)), I encountered the following error.

```bash
➜  pdf-crop-margins -v -p 0 -a -6 Presentation1.pdf
...

Caught an unexpected exception in the pdfCropMargins program.
Unexpected error:  <class 'PyPDF2.errors.PdfReadError'>
Error message   :  Not encrypted file

  File "/xxx/lib/python3.8/site-packages/pdfCropMargins/pdfCropMargins.py", line 61, in main
    crop()
  File "/xxx/lib/python3.8/site-packages/pdfCropMargins/pdfCropMargins.py", line 174, in crop
    output_doc_pathname = main_crop(argv_list)
  File "/xxx/lib/python3.8/site-packages/pdfCropMargins/main_pdfCropMargins.py", line 1449, in main_crop
    process_pdf_file(input_doc_pathname, fixed_input_doc_pathname, output_doc_pathname)
  File "/xxx/lib/python3.8/site-packages/pdfCropMargins/main_pdfCropMargins.py", line 1102, in process_pdf_file
    input_doc.decrypt("")
  File "/xxx/lib/python3.8/site-packages/PyPDF2/_reader.py", line 1607, in decrypt
    raise PdfReadError("Not encrypted file")
```

## Fixes

`PyPDF2` (at least with version `2.5.0`) throws `PdfReadError` instead of `KeyError` when the input file is not encrypted. We need to catch `PdfReadError` as well.

## Version info

```bash
➜  python -c "import PyPDF2; print(PyPDF2.__version__)"
2.5.0

➜  python -c "import pdfCropMargins; print(pdfCropMargins.__version__)"
1.0.8

➜  lsb_release -a 
Distributor ID: Ubuntu
Description:    Ubuntu 22.04 LTS
Release:        22.04
Codename:       jammy
```
