### PR TITLE
Clarify error message for `pageRatioWeights`

### DIFF
--- a/src/pdfCropMargins/main_pdfCropMargins.py
+++ b/src/pdfCropMargins/main_pdfCropMargins.py
@@ -774,7 +774,7 @@ def process_command_line_arguments(parsed_args, cmd_parser):
     if args.pageRatioWeights:
         for w in args.pageRatioWeights:
             if w <= 0:
-                print("\nError in pdfCropMargins: Negative weight argument passed "
+                print("\nError in pdfCropMargins: Non-positive weight argument passed "
                       "to pageRatiosWeights.", file=sys.stderr)
                 ex.cleanup_and_exit(1)
 


### PR DESCRIPTION
Zero is also disallowed, but the error message was only mentioning negative numbers. So, I changed it to say "non-positive". Let me know if this message is fine to you or if I should try to make the error message even more explicit.